### PR TITLE
Fix #35.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='botbot',
-    version='0.2.1',
+    version='0.2.2',
     description='A meta-bot for Euphoria.',
     author='Rishov Sarkar',
     url='https://github.com/ArkaneMoose/BotBot',

--- a/source/botbot.py
+++ b/source/botbot.py
@@ -201,7 +201,7 @@ class BotBot(eu.ping_room.PingRoom, eu.chat_room.ChatRoom, agentid_room.AgentIdR
                 self.send_chat('/me is restarting...', msg_id)
                 self.quit()
 
-    def cleanup(self):
+    def quit(self):
+        super().quit()
         self.bots.quit()
-
         self.botthread.join()


### PR DESCRIPTION
This will hopefully fix #35 by doing BotBot's cleanup on `quit()` rather than on `cleanup()`, which appears to be called on every disconnect.

The rationale behind this change is described in [this comment on #35](https://github.com/ArkaneMoose/BotBot/issues/35#issuecomment-156318579).
